### PR TITLE
No more beta/rc versions: build number of 1.16.4 instead

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -176,7 +176,7 @@ function checkUpdate() {
   if (u0Beta) {
     vermask = /tree\/firefox\-legacy\-(\d+\.\d+\.\w+)$/;
   } else {
-    vermask = /tree\/firefox\-legacy\-(\d+\.\d+\.\d+)$/;
+    vermask = /tree\/firefox\-legacy\-(\d+\.\d+\.\d+(?:\.\d+)?)$/;
   }
   request.open("GET", "https://github.com/gorhill/uBlock");
   request.responseType = "document";


### PR DESCRIPTION
Most likely I won't increase version number beyond 1.16.4, and I will instead release build revisions, and use the fourth number as build revision. I want to avoid confusion with the non-legacy build versions.